### PR TITLE
Enhancement to Crier role

### DIFF
--- a/_includes/default_roles/crier.md
+++ b/_includes/default_roles/crier.md
@@ -2,7 +2,7 @@ A _Crier_ reminds us in Slack of upcoming meetings.
 
 **One Business Day Before The Meeting**
 
-* [ ] *Announce* the meeting in our [Slack][chat]{:target="_blank"}.
+* [ ] *Announce* the meeting in the [Slack channel][chat]{:target="_blank"} of our working group.
 * [ ] *Send the announcement* to [#general]{:target="_blank"} using the `Share` arrow.
 
 <img src="https://user-images.githubusercontent.com/9609562/220438340-2fed944a-142b-4217-bcae-5c0e0110ed05.png" width="500px" />
@@ -18,6 +18,8 @@ A _Crier_ reminds us in Slack of upcoming meetings.
      * Meeting day/time
      * Call info
 * An excellent way to keep participants and non-participants intrigued is to include interesting agenda items from the calendar invite in the announcement. 
+* You can schedule Slack messages ahead of time. Write your message, click on the _down_ arrow by the side of the _send_ button and select _Custom time_.
+     * You cannot easily automate the forwarding of this message to [#general]{:target="_blank"}. Alternatively, it is a good idea to set a reminder for yourself to do it at the time you schedule your message.
 
 [#general]: https://app.slack.com/client/T04PXKRM0/C04PXKRN4
 


### PR DESCRIPTION
Added tip on how to schedule Slack messages ahead of time.
Action item from: https://docs.google.com/document/d/1yIADdTuUJTgA162CUi8yeDRgiKOVBZi3AY6Ukhjzobg/edit