### PR TITLE
Add backlink to InnerSource commons communities

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,6 +3,8 @@
 title: "Name of Your Working Group"
 description: "Description of Your Working Group"
 
+backlink: InnerSource Commons, https://innersourcecommons.org/community/
+
 # The name only of your repo exactly.
 baseurl: "repo-name" 
 


### PR DESCRIPTION
See the **Community Hub** at https://github.com/mrsanz/jekyll-roles-theme#configure-your-_configyaml.

This will create a backlink to the InnerSource website as a Community Hub.

As this is a Jekyll theme used by our work groups (at least by the ISPO Work Group (https://innersourcecommons.github.io/ispo-working-group/), this setting will be used by all work groups using this theme.

This is how it will look once used (ignore the GitHub repository link on the top right, that's work in progress - https://github.com/mrsanz/jekyll-roles-theme/issues/28#issuecomment-1843401413 - not included in this PR):
<img width="1168" alt="image" src="https://github.com/InnerSourceCommons/working-group-roles/assets/54676965/42ccd100-021b-46c3-87a4-dc6b0cf7d528">
