### PR TITLE
Enhancement: Local development with Docker

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,0 +1,12 @@
+FROM ruby:3.2
+
+WORKDIR /usr/src/app
+
+COPY Gemfile /usr/src/app
+COPY jekyll-roles-theme.gemspec /usr/src/app
+
+# Update bundler to the lastest version
+RUN bundle install
+
+# on --host "0.0.0.0", see https://stackoverflow.com/a/51404865
+CMD bundle exec jekyll serve --host "0.0.0.0"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Working Group Roles
 
-This repo helps you to generate a documentation page describing roles to use to run your working group meetings.
+This repo provides a [Jekyll theme](https://jekyllrb.com/docs/themes/) that helps you to generate a documentation page describing roles to use to run your working group meetings.
 Multiple working groups in the InnerSource Commons have found these roles to be a useful way to distribute the tasks associated with running meetings of the working group.
 Distributing this work makes the load easier for each person, spreads knowledge about running the group to multiple people, and keeps multiple people engaged and interested in the working group.
 
@@ -34,3 +34,23 @@ See [this discussion](https://nickang.com/2018-03-05-markdown-bullet-points-hyph
 GitHub allows leaving comments on a line-by-line basis.
 Reviewing and commenting the submitted text is much easier if there are multiple lines on which to leave comments.
 Sentences on consecutive lines will be collapsed into a single paragraph (like this one) in the final rendering of the content.
+
+### Developing 
+
+To test your changes to the theme locally, you can preview the theme using the same command used to preview a Jekyll website:
+
+```bash
+# install the dependencies 
+bundle install
+
+# serve the website with jekyll
+jekyll serve
+```
+
+If you have an environment able to run containers that is compatible with _Docker Compose_ (e.g. Docker Desktop or Podman), run the website locally with the following command:
+
+```bash
+docker compose up
+```
+
+You should be able to access the website at <http://localhost:4000>.

--- a/_config.yml
+++ b/_config.yml
@@ -5,11 +5,11 @@ description: "Description of Your Working Group"
 
 backlink: InnerSource Commons, https://innersourcecommons.org/community/
 
-# The name only of your repo exactly. Uncomment the line below when you copy this file.
+# The name only of your repo exactly, with a leading "/". Uncomment the line below when you copy this file.
 # It is commented to facilitate the local development of this theme
 # baseurl: "/repo-name" 
 
-# This should stay as "https://innersourcecommons.github.io/"
+# This should stay as "https://innersourcecommons.github.io"
 url: "https://innersourcecommons.github.io"
 
 links:

--- a/_config.yml
+++ b/_config.yml
@@ -3,11 +3,12 @@
 title: "Name of Your Working Group"
 description: "Description of Your Working Group"
 
-# The name only of your repo exactly.
-baseurl: "repo-name" 
+# The name only of your repo exactly. Uncomment the line below when you copy this file.
+# It is commented to facilitate the local development of this theme
+# baseurl: "/repo-name" 
 
 # This should stay as "https://innersourcecommons.github.io/"
-url: "https://innersourcecommons.github.io/"
+url: "https://innersourcecommons.github.io"
 
 links:
   # The web URL to your Slack channel.

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1,4 +1,2 @@
----
----
 @charset "utf-8";
 @import "main";

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3.0"
+services:
+  github-pages:
+    build:
+      context: .
+      dockerfile: ./Dockerfile.local
+    volumes:
+      - .:/usr/src/app
+    ports:
+      - 4000:4000

--- a/index.md
+++ b/index.md
@@ -1,0 +1,9 @@
+---
+layout: home
+---
+
+<!-- This file is provided only for local testing -->
+
+# Your test home page
+
+This is a test home page, to be used when you are developing this Jekyll Theme.

--- a/jekyll-roles-theme.gemspec
+++ b/jekyll-roles-theme.gemspec
@@ -14,6 +14,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "jekyll", ">= 3.6", "< 5.0"
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", ">= 1.16"
   spec.add_development_dependency "rake", "~> 12.0"
 end


### PR DESCRIPTION
This commit enables local development of the Jekyll theme with a Docker Compose compatible environment.

I have adjusted the `base_url` and `url` to optimize for local development and also handle the leading and trailing `/`s as per https://mademistakes.com/mastering-jekyll/site-url-baseurl/#how-to-use-url-and-baseurl.

I had to do a few adjustments:
- `index.md` was added to have a home page for local testing
- the bundler dev dependency was adapted to work with the version used on the standard ruby containers
- I had to remove the front matter from `assets/css/main.scss` as it was causing an error on scss parser used by Jekyll

One important remark, the theme does not include the github-pages Gem as a dependency, so, when testing the theme, some things will behave different, because the default plugins included in the Gem will be missing. 
This is not yet included in the documentation, but it would be a good inclusion to set the expectation of contributors.

## Relates links and references
- https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/about-github-pages-and-jekyll#plugins