### PR TITLE
Update the Crier role

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,5 +24,8 @@ links:
   # This is used to remember to reach out to those that used to come but then don't show for a while.
   attendance: 
 
+  # Optional: The link to join the regular meeting of your working group (e.g link a Jitsi or Zoom meeting)
+  meeting_link:
+
 # This should stay as InnerSourceCommons/working-group-roles
 remote_theme: InnerSourceCommons/working-group-roles

--- a/_includes/default_roles/crier.md
+++ b/_includes/default_roles/crier.md
@@ -3,7 +3,10 @@ A _Crier_ reminds us in Slack of upcoming meetings.
 **One Business Day Before The Meeting**
 
 * [ ] *Announce* the meeting in the [Slack channel][chat]{:target="_blank"} of our working group.
-* [ ] *Send the announcement* to [#general]{:target="_blank"} using the `Share` arrow.
+    * Include a link to the meeting notes, you can find them in the [shared document folder][folder]{:target="_blank"}
+{% if site.links.meeting_link != nil %}    * Include a [link to join the meeting][meeting_link]{:target="_blank"}
+{% endif %}
+* [ ] *Send the announcement* to [#general]{:target="_blank"} using the `Share` arrow.  
 
 <img src="https://user-images.githubusercontent.com/9609562/220438340-2fed944a-142b-4217-bcae-5c0e0110ed05.png" width="500px" />
 


### PR DESCRIPTION
This commit updates the Crier role with a link to the folder where the meeting notes are, plus an optional link to join the meeting.

To add the link to join the meeting, the property `links.meeting_link` has to be set in `_config.yml`.

Related issues:
- https://github.com/InnerSourceCommons/ispo-working-group/issues/87

![image](https://github.com/InnerSourceCommons/working-group-roles/assets/260113/130797ba-1167-445e-941a-43eb8ff925d6)